### PR TITLE
Fix 404 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This template offers an easy way to get started writing a javascript action with
 
 ## Getting Started
 
-See the walkthrough located [here](https://github.com/actions/toolkit/blob/master/docs/node12-action.md).
+See the walkthrough located [here](https://github.com/actions/toolkit/blob/master/docs/javascript-action.md).
 
 In addition to walking your through how to create an action, it also provides strategies for versioning, releasing and referencing your actions.


### PR DESCRIPTION
The current link 404s for me, but I think it's trying to point to: https://github.com/actions/toolkit/blob/master/docs/javascript-action.md